### PR TITLE
AB#13

### DIFF
--- a/devops.yml
+++ b/devops.yml
@@ -28,6 +28,12 @@ steps:
     artifactName: 'angular'
     targetPath: 'dist'
 
+- task: PublishBuildArtifacts@1
+  displayName: 'Republish distribution'
+  inputs:
+    PathtoPublish: 'dist'
+    ArtifactName: buildartifacts
+
 - task: Npm@1
   displayName: 'Test Angular'
   inputs:
@@ -52,3 +58,26 @@ steps:
     testRunTitle: Angular
     testResultsFormat: JUnit
     testResultsFiles: "**/TESTS*.xml"
+
+- task: Npm@1
+  displayName: 'Lint Angular'
+  inputs:
+    command: custom
+    customCommand: run lint --  --format=stylish
+    workingDir: ./
+
+- task: Npm@1
+  displayName: 'E2E Test Angular'
+  inputs:
+    command: custom
+    customCommand: run e2e
+    workingDir: src/angular7
+
+- task: PublishTestResults@2
+  displayName: 'Publish Angular E2E test results'
+  condition: succeededOrFailed()
+  inputs:
+    searchFolder: $(System.DefaultWorkingDirectory)/e2e/junit
+    testRunTitle: Angular_E2E
+    testResultsFormat: JUnit
+    testResultsFiles: "**/junit*.xml"

--- a/devops.yml
+++ b/devops.yml
@@ -71,7 +71,7 @@ steps:
   inputs:
     command: custom
     customCommand: run e2e
-    workingDir: src/angular7
+    workingDir: ./
 
 - task: PublishTestResults@2
   displayName: 'Publish Angular E2E test results'

--- a/e2e/junit/junitresults.xml
+++ b/e2e/junit/junitresults.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites disabled="0" errors="0" failures="0" tests="1" time="0.713">
+ <testsuite name="workspace-project App" timestamp="2019-04-21T17:27:05" hostname="localhost" time="0.713" errors="0" tests="1" skipped="0" disabled="0" failures="0">
+  <testcase classname="workspace-project App" name="should display welcome message" time="0.711" />
+ </testsuite>
+</testsuites>

--- a/e2e/protractor.conf.js
+++ b/e2e/protractor.conf.js
@@ -2,6 +2,9 @@
 // https://github.com/angular/protractor/blob/master/lib/config.ts
 
 const { SpecReporter } = require('jasmine-spec-reporter');
+const { JUnitXmlReporter } = require('jasmine-reporters');
+
+process.env.CHROME_BIN = process.env.CHROME_BIN || require("puppeteer").executablePath();
 
 exports.config = {
   allScriptsTimeout: 11000,
@@ -9,10 +12,10 @@ exports.config = {
     './src/**/*.e2e-spec.ts'
   ],
   capabilities: {
+    'browserName': 'chrome',
     chromeOptions: {
       args: [ "--headless" ]
     },
-    'browserName': 'chrome'
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',
@@ -27,5 +30,12 @@ exports.config = {
       project: require('path').join(__dirname, './tsconfig.e2e.json')
     });
     jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
+
+    var junitReporter = new JUnitXmlReporter({
+      savePath: require('path').join(__dirname, './junit'),
+      consolidateAll: true
+    });
+    
+    jasmine.getEnv().addReporter(junitReporter);
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5437,6 +5437,16 @@
       "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
       "dev": true
     },
+    "jasmine-reporters": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.3.2.tgz",
+      "integrity": "sha512-u/7AT9SkuZsUfFBLLzbErohTGNsEUCKaQbsVYnLFW1gEuL2DzmBL4n8v90uZsqIqlWvWUgian8J6yOt5Fyk/+A==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "xmldom": "^0.1.22"
+      }
+    },
     "jasmine-spec-reporter": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-4.2.1.tgz",
@@ -10501,6 +10511,12 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
       "dev": true
     },
     "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "~8.9.4",
     "codelyzer": "~4.5.0",
     "jasmine-core": "~2.99.1",
+    "jasmine-reporters": "^2.3.2",
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "~4.0.0",
     "karma-chrome-launcher": "~2.2.0",


### PR DESCRIPTION
added linting and fixed up the e2e reporter to support the runner changes made earlier. this should allow Azure DevOps pipeline to test, cover, lint and run an end-to-end conversion on the entire application